### PR TITLE
Fix crash in Gui::log() when the log list is empty

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -17,12 +17,18 @@ namespace Gui {
     void mainLoop();
 
     void log(const std::string_view rt_fmt_str, auto&&... args) {
-        std::string str = std::vformat(rt_fmt_str, std::make_format_args(args...));
-        if (str == logs.back().first)
-            logs.back().second++;
-        else
-            logs.emplace_back(str, 0);
+    std::string str = std::vformat(rt_fmt_str, std::make_format_args(args...));
+
+    if (logs.empty()) {
+        logs.emplace_back(str, 0);
+        return;
     }
+
+    if (str == logs.back().first)
+        logs.back().second++;
+    else
+        logs.emplace_back(str, 0);
+}
 
     void addWindow(Window* window);
     template <typename T>


### PR DESCRIPTION
## Summary

Fixes a crash caused by calling `Gui::log()` before any log entries exist.

## Cause

`Gui::log()` compares the formatted message against `logs.back().first` without checking whether `logs` is empty.

On the first call to Gui::log(), logs is empty. Calling std::list::back() on an empty list triggers an assertion failure in debug builds and results in undefined behavior otherwise.

## Fix

Add an `empty()` check before accessing `logs.back()`. If the log list is empty, insert the first log entry and return.

## Tested

- Fedora 44
- GCC 16
- Wayland

Built from source and verified that CheatTurbine no longer crashes on startup.